### PR TITLE
Consistent line ending and prevent dropping first line when parsing body

### DIFF
--- a/src/Teon/DKIM/AbstractDKIM.php
+++ b/src/Teon/DKIM/AbstractDKIM.php
@@ -201,6 +201,7 @@ abstract class AbstractDKIM {
         $lines = explode("\n", $this->_raw);
         // Jump past all the headers
         $on = false;
+        $line = '';
         while ($line = array_shift($lines)) {
             // Remove trailing carriage-return if present
             // It might be present if emails are read from Unix maildirs directly instead of via IMAP/POP3
@@ -213,9 +214,9 @@ abstract class AbstractDKIM {
                 $on = true;
             }
         }
-        
-        return implode("\r\n", $lines);
-        
+
+        return "$line\n" . implode("\n", $lines);
+
     }
     
     /**


### PR DESCRIPTION
There were two issues:
- Body is exploded on \n and imploded on \n\r, causing lines to end with \n\r\r
- The first line of the body was being dropped when it was compared with an empty string

These issues were causing invalid signatures, which caused valid DKIM signatures to fail validation